### PR TITLE
Update Vision API call to correct URL

### DIFF
--- a/csharp/ResizeImage/run-module5.csx
+++ b/csharp/ResizeImage/run-module5.csx
@@ -24,7 +24,7 @@ public static async Task<object> Run(Stream myBlob, string name, Stream thumbnai
 var request = new HttpRequestMessage() {
     RequestUri = new Uri(
         System.Environment.GetEnvironmentVariable("COMP_VISION_URL", EnvironmentVariableTarget.Process) + 
-        "/analyze?visualFeatures=Description&amp;language=en"),
+        "/vision/v2.0/analyze?visualFeatures=Description&amp;language=en"),
         Method = HttpMethod.Post,
         Content = new StreamContent(myBlob)
     };


### PR DESCRIPTION
Base on feedback and comments at https://social.msdn.microsoft.com/Forums/en-US/ccce7fd2-ae5d-40f7-b283-ad26c533496c/add-image-captions-with-computer-vision?forum=AzureFunctions.

No progress seem to have been made for 3 months.

These modifications worked for me